### PR TITLE
[FT] swagger 플러그인 변경

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -8,6 +8,5 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-webflux") // MVC 에서도 일단 사용하는 걸로..
     implementation("com.google.firebase:firebase-admin:7.1.0")
-    implementation("io.springfox:springfox-swagger2:2.9.2")
-    implementation("io.springfox:springfox-swagger-ui:2.9.2")
+    implementation("org.springdoc:springdoc-openapi-ui:1.5.+")
 }

--- a/api/src/main/kotlin/config/SwaggerConfig.kt
+++ b/api/src/main/kotlin/config/SwaggerConfig.kt
@@ -1,34 +1,48 @@
 package waffle.guam.community.config
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition
+import io.swagger.v3.oas.annotations.info.Info
+import io.swagger.v3.oas.models.parameters.Parameter
+import org.springdoc.core.GroupedOpenApi
+import org.springdoc.core.SpringDocUtils
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import springfox.documentation.builders.ApiInfoBuilder
-import springfox.documentation.builders.PathSelectors
-import springfox.documentation.builders.RequestHandlerSelectors
-import springfox.documentation.service.ApiInfo
-import springfox.documentation.spi.DocumentationType
-import springfox.documentation.spring.web.plugins.Docket
-import springfox.documentation.swagger2.annotations.EnableSwagger2
+import waffle.guam.community.common.UserContext
 
+@OpenAPIDefinition(
+    info = Info(
+        title = "GCS API",
+        description = "Guam Community Server API"
+    )
+)
 @Configuration
-@EnableSwagger2
-class Swagger2Config {
-    @Bean
-    fun api(): Docket {
-        return Docket(DocumentationType.SWAGGER_2)
-            .select()
-            .apis(RequestHandlerSelectors.basePackage("waffle.guam.community.controller"))
-            .paths(PathSelectors.regex("/.*"))
-            .build()
-            .apiInfo(apiInfo())
-    }
+class SwaggerConfig {
 
-    private fun apiInfo(): ApiInfo {
-        return ApiInfoBuilder().apply {
-            title("Guam-Community API documentation")
-            description("API Endpoints")
-            license("WaffleStudio")
-            licenseUrl("https://github.com/wafflestudio/guam-community-server")
-        }.build()
+    @Bean
+    fun api(): GroupedOpenApi {
+        SpringDocUtils
+            .getConfig()
+            .addRequestWrapperToIgnore(UserContext::class.java) // Hide UserContext
+
+        return GroupedOpenApi
+            .builder()
+            .group("guam")
+            .pathsToMatch("/**")
+            .addOpenApiCustomiser { openApi ->
+                // auth 관련 API 빼고 Operation (API)에 인증 헤더를 추가해서 보여준다.
+                // https://github.com/springdoc/springdoc-openapi/issues/708
+                openApi.paths
+                    .filterNot { (pathName, _) -> pathName.contains("/auth") }
+                    .flatMap { (_, pathItem) -> pathItem.readOperations() }
+                    .forEach { operation ->
+                        operation.addParametersItem(
+                            Parameter()
+                                .`in`("header")
+                                .name("Authorization")
+                                .required(true)
+                        )
+                    }
+            }
+            .build()
     }
 }

--- a/api/src/main/kotlin/config/SwaggerConfig.kt
+++ b/api/src/main/kotlin/config/SwaggerConfig.kt
@@ -2,7 +2,8 @@ package waffle.guam.community.config
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition
 import io.swagger.v3.oas.annotations.info.Info
-import io.swagger.v3.oas.models.parameters.Parameter
+import io.swagger.v3.oas.models.security.SecurityRequirement
+import io.swagger.v3.oas.models.security.SecurityScheme
 import org.springdoc.core.GroupedOpenApi
 import org.springdoc.core.SpringDocUtils
 import org.springframework.context.annotation.Bean
@@ -26,22 +27,19 @@ class SwaggerConfig {
 
         return GroupedOpenApi
             .builder()
-            .group("guam")
-            .pathsToMatch("/**")
+            .group("GUAM API")
             .addOpenApiCustomiser { openApi ->
-                // auth 관련 API 빼고 Operation (API)에 인증 헤더를 추가해서 보여준다.
-                // https://github.com/springdoc/springdoc-openapi/issues/708
-                openApi.paths
-                    .filterNot { (pathName, _) -> pathName.contains("/auth") }
-                    .flatMap { (_, pathItem) -> pathItem.readOperations() }
-                    .forEach { operation ->
-                        operation.addParametersItem(
-                            Parameter()
-                                .`in`("header")
-                                .name("Authorization")
-                                .required(true)
-                        )
-                    }
+                openApi
+                    .addSecurityItem(SecurityRequirement().addList("FCM Token"))
+                    .components.addSecuritySchemes(
+                        "FCM Token",
+                        SecurityScheme()
+                            .name("Authorization")
+                            .type(SecurityScheme.Type.HTTP)
+                            .`in`(SecurityScheme.In.HEADER)
+                            .bearerFormat("JWT")
+                            .scheme("bearer")
+                    )
             }
             .build()
     }

--- a/api/src/main/kotlin/config/UserContextResolver.kt
+++ b/api/src/main/kotlin/config/UserContextResolver.kt
@@ -37,7 +37,13 @@ class UserContextResolver(
     ): UserContext {
         val req = (webRequest.nativeRequest as HttpServletRequest)
         val userContext = req.getHeader(HttpHeaders.AUTHORIZATION)
-            ?.let { token -> authService.verify(token) }
+            ?.split(' ')
+            ?.takeIf { parsedHeader ->
+                "Bearer" == parsedHeader.first()
+            }?.let { parsedHeader ->
+                val token = parsedHeader.last()
+                authService.verify(token)
+            }
             ?: throw InvalidFirebaseTokenException("토큰 정보를 찾을 수 없습니다.")
 
         logger.info("[USER-${userContext.id}] ${req.method} : ${req.requestURI}")

--- a/api/src/main/kotlin/controller/comment/PostCommentController.kt
+++ b/api/src/main/kotlin/controller/comment/PostCommentController.kt
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import waffle.guam.community.common.UserContext
 import waffle.guam.community.controller.comment.req.CreatePostCommentRequest
 import waffle.guam.community.service.command.comment.CreatePostComment
 import waffle.guam.community.service.command.comment.CreatePostCommentHandler
@@ -19,12 +20,14 @@ class PostCommentController(
 ) {
     @PostMapping("/{postId}/comments")
     fun create(
+        userContext: UserContext,
         @PathVariable postId: Long,
         @RequestBody req: CreatePostCommentRequest
     ) = createPostCommentHandler.handle(CreatePostComment(postId = postId, userId = 1L, content = req.content))
 
     @PostMapping("/{postId}/comments/{commentId}")
     fun delete(
+        userContext: UserContext,
         @PathVariable postId: Long,
         @PathVariable commentId: Long
     ) = deletePostCommentHandler.handle(DeletePostComment(postId = postId, userId = 1L, commentId = commentId))

--- a/api/src/main/kotlin/controller/like/PostCommentLikeController.kt
+++ b/api/src/main/kotlin/controller/like/PostCommentLikeController.kt
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import waffle.guam.community.common.UserContext
 import waffle.guam.community.service.command.like.CreatePostCommentLike
 import waffle.guam.community.service.command.like.CreatePostCommentLikeHandler
 import waffle.guam.community.service.command.like.DeletePostCommentLike
@@ -18,12 +19,14 @@ class PostCommentLikeController(
 ) {
     @PostMapping("/{postId}/comments/{commentId}/likes")
     fun create(
+        userContext: UserContext,
         @PathVariable postId: Long,
         @PathVariable commentId: Long,
     ) = createPostCommentLikeHandler.handle(CreatePostCommentLike(postId = postId, commentId = commentId, userId = 1L))
 
     @DeleteMapping("/{postId}/comments/{commentId}/likes")
     fun delete(
+        userContext: UserContext,
         @PathVariable postId: Long,
         @PathVariable commentId: Long,
     ) = deletePostCommentLikeHandler.handle(DeletePostCommentLike(postId = postId, commentId = commentId, userId = 1L))

--- a/api/src/main/kotlin/controller/like/PostLikeController.kt
+++ b/api/src/main/kotlin/controller/like/PostLikeController.kt
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import waffle.guam.community.common.UserContext
 import waffle.guam.community.service.command.like.CreatePostLike
 import waffle.guam.community.service.command.like.CreatePostLikeHandler
 import waffle.guam.community.service.command.like.DeletePostLike
@@ -18,11 +19,13 @@ class PostLikeController(
 ) {
     @PostMapping("/{postId}/likes")
     fun create(
+        userContext: UserContext,
         @PathVariable postId: Long,
     ) = createPostLikeHandler.handle(CreatePostLike(postId = postId, userId = 1L))
 
     @DeleteMapping("/{postId}/likes")
     fun delete(
+        userContext: UserContext,
         @PathVariable postId: Long
     ) = deletePostLikeHandler.handle(DeletePostLike(postId = postId, userId = 1L))
 }

--- a/api/src/main/kotlin/controller/post/PostController.kt
+++ b/api/src/main/kotlin/controller/post/PostController.kt
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import waffle.guam.community.common.UserContext
 import waffle.guam.community.controller.post.req.CreatePostRequest
 import waffle.guam.community.service.command.post.CreatePostHandler
 import waffle.guam.community.service.command.post.DeletePost
@@ -23,22 +24,26 @@ class PostController(
 ) {
     @PostMapping("")
     fun createPost(
+        userContext: UserContext,
         @ModelAttribute req: CreatePostRequest,
     ) = createPostHandler.handle(req.toCommand(1L))
 
     @DeleteMapping("/{postId}")
     fun deletePost(
+        userContext: UserContext,
         @PathVariable postId: Long,
     ) = deletePostHandler.handle(DeletePost(postId = postId, userId = 1L))
 
     @GetMapping("")
     fun getPosts(
+        userContext: UserContext,
         @RequestParam boardId: Long,
         @RequestParam(required = false) afterPostId: Long?,
     ) = postDisplayer.getPostPreviewList(boardId = 1L, afterPostId = afterPostId)
 
     @GetMapping("", params = ["keyword"])
     fun searchPosts(
+        userContext: UserContext,
         @RequestParam boardId: Long,
         @RequestParam tag: String,
         @RequestParam keyword: String,
@@ -47,6 +52,7 @@ class PostController(
 
     @GetMapping("/{postId}")
     fun getPost(
+        userContext: UserContext,
         @PathVariable postId: Long,
     ) = postDisplayer.getPostDetail(postId = postId)
 }


### PR DESCRIPTION
## 배경

- UserContext -> 인증 토큰으로 바꾸고자 함

## 작업 내용

- Springfox -> Springdoc 이전
  - [SpringDoc](https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-ui) 이 SpringFox 보다 더 잘 관리되는 듯 보임
  -  OpenAPI 3.0 지원하길래..

- UserContext 가리고 인증 토큰 모든 API에 걸어줌

## 참고

원래는 [springFox 그대로 써서](https://springfox.github.io/springfox/docs/current/#example-parameterbuilderplugin) userContext 있을 때만 헤더로 바꿔주려고 했는데 ,, 잘 안되고 간편한 방법이 없어서 ㅜ 이렇게 했읍니다
