### PR TITLE
.gitignore Secret 워크플로우에 안전하게 등록

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           arguments: build
 
+      - name: Add Firebase Secret File
+        run: echo ${{ secrets.FIREBASE_SDK }} | base64 --decode > ${{ secrets.FIREBASE_SDK_PATH }}
+
       - name: Build Docker Image
         run: docker build -t ${{ secrets.DCR_NAME }} .
         # NO Tag Versioning Now


### PR DESCRIPTION
## 배경


## 작업 내용

파베 정보 base64 인코딩 후 레포 시크릿에 저장
워크플로우 컨테이너 빌드 직전에 디코딩 해서 필요한 위치에 넣어둠

## 참고

