### PR TITLE
swagger 인증 관련 변경

### DIFF
--- a/community/api/src/main/kotlin/config/SwaggerConfig.kt
+++ b/community/api/src/main/kotlin/config/SwaggerConfig.kt
@@ -2,8 +2,7 @@ package waffle.guam.community.config
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition
 import io.swagger.v3.oas.annotations.info.Info
-import io.swagger.v3.oas.models.security.SecurityRequirement
-import io.swagger.v3.oas.models.security.SecurityScheme
+import io.swagger.v3.oas.models.parameters.Parameter
 import org.springdoc.core.GroupedOpenApi
 import org.springdoc.core.SpringDocUtils
 import org.springframework.context.annotation.Bean
@@ -28,18 +27,13 @@ class SwaggerConfig {
         return GroupedOpenApi
             .builder()
             .group("Guam")
-            .addOpenApiCustomiser { openApi ->
-                openApi
-                    .addSecurityItem(SecurityRequirement().addList("FCM Token"))
-                    .components.addSecuritySchemes(
-                        "FCM Token",
-                        SecurityScheme()
-                            .name("Authorization")
-                            .type(SecurityScheme.Type.HTTP)
-                            .`in`(SecurityScheme.In.HEADER)
-                            .bearerFormat("JWT")
-                            .scheme("bearer")
-                    )
+            .addOperationCustomizer { operation, _ ->
+                operation.addParametersItem(
+                    Parameter()
+                        .`in`("header")
+                        .required(false)
+                        .name(GATEWAY_HEADER_NAME)
+                )
             }
             .build()
     }

--- a/community/api/src/main/kotlin/config/UserContextResolver.kt
+++ b/community/api/src/main/kotlin/config/UserContextResolver.kt
@@ -9,6 +9,8 @@ import waffle.guam.community.common.MissingHeaderException
 import waffle.guam.community.common.UserContext
 import javax.servlet.http.HttpServletRequest
 
+const val GATEWAY_HEADER_NAME = "X-GATEWAY-USER-ID"
+
 class UserContextResolver : HandlerMethodArgumentResolver {
     override fun supportsParameter(parameter: MethodParameter): Boolean =
         UserContext::class.java.isAssignableFrom(parameter.parameterType)
@@ -21,6 +23,6 @@ class UserContextResolver : HandlerMethodArgumentResolver {
     ): UserContext {
         val req = (webRequest.nativeRequest as HttpServletRequest)
 
-        return req.getHeader("X-GATEWAY-USER-ID")?.toLong()?.let(::UserContext) ?: throw MissingHeaderException()
+        return req.getHeader(GATEWAY_HEADER_NAME)?.toLong()?.let(::UserContext) ?: throw MissingHeaderException()
     }
 }


### PR DESCRIPTION
## 배경

인증 모듈 분리로 인해 스웨거 작동이 기존대로 안됨

## 작업 내용

gateway 서버를 거치지 않고 헤더를 주입받을 수 있도록 설정 변경

## 참고

